### PR TITLE
refactor: ui framework integrations

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+import { react, solid, preact, vue, svelte, alpinejs } from '@storybook/astro/integrations';
+
 /** @type { import('@storybook/astro').StorybookConfig } */
 const config = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -10,13 +12,19 @@ const config = {
     name: '@storybook/astro',
     options: {
       integrations: [
-        'alpine',
-        'svelte',
-        'preact',
-        'vue',
-        'react',
-        'solid'
-      ],
+        react({
+          include: ['**/react/*']
+        }),
+        solid({
+          include: ['**/solid/*']
+        }),
+        preact({
+          include: ['**/preact/*']
+        }),
+        vue(),
+        svelte(),
+        alpinejs()
+      ]
     },
   },
 };

--- a/packages/@storybook/astro-renderer/package.json
+++ b/packages/@storybook/astro-renderer/package.json
@@ -4,6 +4,7 @@
   "module": "./preset.js",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     "./types": "./src/types.ts",
     "./*": "./src/*"
   },

--- a/packages/@storybook/astro-renderer/src/render.tsx
+++ b/packages/@storybook/astro-renderer/src/render.tsx
@@ -3,16 +3,15 @@ import type { ArgsStoryFn, RenderContext } from 'storybook/internal/types';
 import { dedent } from 'ts-dedent';
 import 'astro:scripts/page.js';
 import type { $FIXME, RenderComponentInput, RenderPromise, RenderResponseMessage } from './types';
-import * as renderers from 'virtual:storybook-renderers';
+import * as renderers from 'virtual:storybook-renderer-fallback';
 
 const messages = new Map<string, RenderPromise>();
 
 export const render: ArgsStoryFn<$FIXME> = (args, context) => {
   const { id, component: Component } = context;
-  
+
   const renderer = context.parameters?.renderer;
 
-  
   if (renderer && Object.hasOwn(renderers, renderer)) {
     return renderers[renderer].render(args, context);
   }

--- a/packages/@storybook/astro-renderer/src/render.tsx
+++ b/packages/@storybook/astro-renderer/src/render.tsx
@@ -89,7 +89,6 @@ export async function renderToCanvas(
     canvasElement.innerHTML = element;
     simulatePageLoad(canvasElement);
   } else if (Object.hasOwn(renderers, renderer)) {
-    // canvasElement.innerHTML = 'just a sec';
     return renderers[renderer].renderToCanvas(ctx, canvasElement);
   } else if (element instanceof window.Node) {
     if (canvasElement.firstChild === element && forceRemount === false) {

--- a/packages/@storybook/astro/package.json
+++ b/packages/@storybook/astro/package.json
@@ -1,23 +1,50 @@
 {
   "name": "@storybook/astro",
   "version": "0.0.1",
-  "module": "./preset.js",
   "type": "module",
+  "exports": {
+    "./integrations": "./src/integrations/index.ts",
+    "./preset": "./preset.ts",
+    "./package.json": "./package.json",
+    "./*": "./src/*"
+  },
   "devDependencies": {
+    "@storybook/preact": "^8.6.12",
+    "@storybook/react": "^8.6.12",
+    "@storybook/svelte": "^8.6.12",
+    "@storybook/vue3": "^8.6.12",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/node": "^20.17.30",
-    "astro": "^5.6.1"
+    "@vitejs/plugin-react": "^4.3.4",
+    "alpinejs": "^3.14.9",
+    "astro": "^5.6.1",
+    "storybook-solidjs": "^1.0.0-beta.7",
+    "vite-plugin-solid": "^2.11.6"
   },
   "peerDependencies": {
-    "@astrojs/preact": "*",
-    "@astrojs/react": "*",
-    "@astrojs/solid-js": "*",
-    "@astrojs/svelte": "*",
-    "@astrojs/vue": "*",
+    "@astrojs/alpinejs": "^0.4.5",
+    "@astrojs/preact": "^4.0.8",
+    "@astrojs/react": "^4.2.3",
+    "@astrojs/solid-js": "^5.0.7",
+    "@astrojs/svelte": "^7.0.9",
+    "@astrojs/vue": "^5.0.9",
+    "@preact/preset-vite": "^2.10.1",
+    "@storybook/preact": "^8.6.12",
+    "@storybook/react": "^8.6.12",
+    "@storybook/svelte": "^8.6.12",
+    "@storybook/vue3": "^8.6.12",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-vue": "^5.2.3",
+    "@vitejs/plugin-vue-jsx": "^4.1.2",
     "astro": "^4.14.6",
-    "storybook": "*",
-    "vite": "*"
+    "storybook": "^8.6.12",
+    "storybook-solidjs": "^1.0.0-beta.7",
+    "vite": "^6.2.5"
   },
   "peerDependenciesMeta": {
+    "@astrojs/alpinejs": {
+      "optional": true
+    },
     "@astrojs/preact": {
       "optional": true
     },
@@ -31,6 +58,30 @@
       "optional": true
     },
     "@astrojs/vue": {
+      "optional": true
+    },
+    "@preact/preset-vite": {
+      "optional": true
+    },
+    "@storybook/preact": {
+      "optional": true
+    },
+    "@storybook/react": {
+      "optional": true
+    },
+    "@storybook/svelte": {
+      "optional": true
+    },
+    "@storybook/vue3": {
+      "optional": true
+    },
+    "@vitejs/plugin-vue": {
+      "optional": true
+    },
+    "@vitejs/plugin-vue-jsx": {
+      "optional": true
+    },
+    "storybook-solidjs": {
       "optional": true
     }
   },

--- a/packages/@storybook/astro/src/integrations/alpine.ts
+++ b/packages/@storybook/astro/src/integrations/alpine.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Record<string, unknown>;
@@ -11,12 +10,11 @@ export class AlpineIntegration implements Integration {
     'alpinejs'
   ];
   readonly options: Options;
+  readonly renderer = {};
 
   constructor(options: Options = {}) {
     this.options = options;
   }
-
-  async addRenderer(_container: AstroContainer): Promise<void> {}
 
   resolveClient(_moduleName: string): undefined {}
 

--- a/packages/@storybook/astro/src/integrations/alpine.ts
+++ b/packages/@storybook/astro/src/integrations/alpine.ts
@@ -1,0 +1,32 @@
+import type { Integration } from './base';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+
+export type Options = Record<string, unknown>;
+
+export class AlpineIntegration implements Integration {
+  readonly name = 'alpine';
+  readonly dependencies = [
+    '@astrojs/alpinejs',
+    'alpinejs'
+  ];
+  readonly options: Options;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+  }
+
+  async addRenderer(_container: AstroContainer): Promise<void> {}
+
+  resolveClient(_moduleName: string): undefined {}
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/alpinejs');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(_ctx: RenderContext, _element: HTMLElement) {
+    return Promise.resolve();
+  }
+}

--- a/packages/@storybook/astro/src/integrations/alpine.ts
+++ b/packages/@storybook/astro/src/integrations/alpine.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Record<string, unknown>;
 
@@ -22,9 +21,5 @@ export class AlpineIntegration implements Integration {
     const framework = await import('@astrojs/alpinejs');
 
     return framework.default(this.options);
-  }
-
-  async renderToCanvas(_ctx: RenderContext, _element: HTMLElement) {
-    return Promise.resolve();
   }
 }

--- a/packages/@storybook/astro/src/integrations/base.ts
+++ b/packages/@storybook/astro/src/integrations/base.ts
@@ -1,5 +1,4 @@
 import type { AstroIntegration } from 'astro';
-import type { RenderContext } from 'storybook/internal/types';
 
 export type RendererDeclaration = {
   server?: {
@@ -17,8 +16,8 @@ export abstract class Integration {
   abstract readonly dependencies: string[];
   abstract readonly options: Record<string | number | symbol, unknown>;
   abstract readonly renderer: RendererDeclaration;
+  abstract readonly storybookEntryPreview?: string;
 
   abstract resolveClient(moduleName: string): string | undefined;
   abstract loadIntegration(): Promise<AstroIntegration>;
-  abstract renderToCanvas(ctx: RenderContext, element: HTMLElement): Promise<void>;
 } 

--- a/packages/@storybook/astro/src/integrations/base.ts
+++ b/packages/@storybook/astro/src/integrations/base.ts
@@ -1,13 +1,23 @@
 import type { AstroIntegration } from 'astro';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
+
+export type RendererDeclaration = {
+  server?: {
+    name: string,
+    entrypoint: string,
+  },
+  client?: {
+    name: string,
+    entrypoint: string,
+  }
+};
 
 export abstract class Integration {
   abstract readonly name: string;
   abstract readonly dependencies: string[];
   abstract readonly options: Record<string | number | symbol, unknown>;
-  
-  abstract addRenderer(container: AstroContainer): Promise<void>;
+  abstract readonly renderer: RendererDeclaration;
+
   abstract resolveClient(moduleName: string): string | undefined;
   abstract loadIntegration(): Promise<AstroIntegration>;
   abstract renderToCanvas(ctx: RenderContext, element: HTMLElement): Promise<void>;

--- a/packages/@storybook/astro/src/integrations/base.ts
+++ b/packages/@storybook/astro/src/integrations/base.ts
@@ -1,0 +1,14 @@
+import type { AstroIntegration } from 'astro';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+
+export abstract class Integration {
+  abstract readonly name: string;
+  abstract readonly dependencies: string[];
+  abstract readonly options: Record<string | number | symbol, unknown>;
+  
+  abstract addRenderer(container: AstroContainer): Promise<void>;
+  abstract resolveClient(moduleName: string): string | undefined;
+  abstract loadIntegration(): Promise<AstroIntegration>;
+  abstract renderToCanvas(ctx: RenderContext, element: HTMLElement): Promise<void>;
+} 

--- a/packages/@storybook/astro/src/integrations/index.ts
+++ b/packages/@storybook/astro/src/integrations/index.ts
@@ -1,0 +1,33 @@
+import { AlpineIntegration, type Options as AlpineOptions } from './alpine';
+import { PreactIntegration, type Options as PreactOptions } from './preact';
+import { ReactIntegration, type Options as ReactOptions } from './react';
+import { SolidIntegration, type Options as SolidOptions } from './solid';
+import { SvelteIntegration, type Options as SvelteOptions } from './svelte';
+import { VueIntegration, type Options as VueOptions } from './vue';
+
+
+export function alpinejs(options?: AlpineOptions) {
+  return new AlpineIntegration(options);
+}
+
+export function preact(options?: PreactOptions) {
+  return new PreactIntegration(options);
+}
+
+export function react(options?: ReactOptions) {
+  return new ReactIntegration(options);
+}
+
+export function solid(options?: SolidOptions) {
+  return new SolidIntegration(options);
+}
+
+export function svelte(options?: SvelteOptions) {
+  return new SvelteIntegration(options);
+}
+
+export function vue(options?: VueOptions) {
+  return new VueIntegration(options);
+}
+
+export type { Integration } from './base';

--- a/packages/@storybook/astro/src/integrations/preact.ts
+++ b/packages/@storybook/astro/src/integrations/preact.ts
@@ -1,0 +1,56 @@
+import type { Integration } from './base';
+import type { PreactPluginOptions } from '@preact/preset-vite';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+
+export type Options = Pick<PreactPluginOptions, 'include' | 'exclude'> & {
+  compat?: boolean;
+  devtools?: boolean;
+};
+
+export class PreactIntegration implements Integration {
+  readonly name = 'preact';
+  readonly dependencies = [
+    '@astrojs/preact',
+    '@storybook/preact',
+    'preact'
+  ];
+  readonly options: Options;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+  }
+
+  async addRenderer(container: AstroContainer): Promise<void> {
+    const mod = await import('@astrojs/preact/server.js');
+
+    container.addServerRenderer({
+      renderer: mod.default,
+      name: '@astrojs/preact'
+    });
+
+    container.addClientRenderer({
+      name: '@astrojs/preact',
+      entrypoint: '@astrojs/preact/client.js'
+    });
+  }
+
+  resolveClient(moduleName: string): string | undefined {
+    if (moduleName.startsWith('@astrojs/preact/client')) {
+      return `/@id/${moduleName}`;
+    }
+  }
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/preact');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+    // @ts-expect-error Missing declaration
+    const { renderToCanvas } = await import('@storybook/preact/dist/entry-preview.mjs');
+
+    return renderToCanvas(ctx, element);
+  }
+}

--- a/packages/@storybook/astro/src/integrations/preact.ts
+++ b/packages/@storybook/astro/src/integrations/preact.ts
@@ -1,6 +1,5 @@
 import type { Integration } from './base';
 import type { PreactPluginOptions } from '@preact/preset-vite';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Pick<PreactPluginOptions, 'include' | 'exclude'> & {
@@ -10,29 +9,22 @@ export type Options = Pick<PreactPluginOptions, 'include' | 'exclude'> & {
 
 export class PreactIntegration implements Integration {
   readonly name = 'preact';
-  readonly dependencies = [
-    '@astrojs/preact',
-    '@storybook/preact',
-    'preact'
-  ];
+  readonly dependencies = ['@astrojs/preact', '@storybook/preact', 'preact'];
   readonly options: Options;
+
+  readonly renderer = {
+    server: {
+      name: '@astrojs/preact',
+      entrypoint: '@astrojs/preact/server.js'
+    },
+    client: {
+      name: '@astrojs/preact',
+      entrypoint: '@astrojs/preact/client.js'
+    }
+  };
 
   constructor(options: Options = {}) {
     this.options = options;
-  }
-
-  async addRenderer(container: AstroContainer): Promise<void> {
-    const mod = await import('@astrojs/preact/server.js');
-
-    container.addServerRenderer({
-      renderer: mod.default,
-      name: '@astrojs/preact'
-    });
-
-    container.addClientRenderer({
-      name: '@astrojs/preact',
-      entrypoint: '@astrojs/preact/client.js'
-    });
   }
 
   resolveClient(moduleName: string): string | undefined {

--- a/packages/@storybook/astro/src/integrations/preact.ts
+++ b/packages/@storybook/astro/src/integrations/preact.ts
@@ -1,6 +1,5 @@
 import type { Integration } from './base';
 import type { PreactPluginOptions } from '@preact/preset-vite';
-import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Pick<PreactPluginOptions, 'include' | 'exclude'> & {
   compat?: boolean;
@@ -11,7 +10,8 @@ export class PreactIntegration implements Integration {
   readonly name = 'preact';
   readonly dependencies = ['@astrojs/preact', '@storybook/preact', 'preact'];
   readonly options: Options;
-
+  readonly storybookEntryPreview = '@storybook/preact/dist/entry-preview.mjs';
+  
   readonly renderer = {
     server: {
       name: '@astrojs/preact',
@@ -37,12 +37,5 @@ export class PreactIntegration implements Integration {
     const framework = await import('@astrojs/preact');
 
     return framework.default(this.options);
-  }
-
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
-    // @ts-expect-error Missing declaration
-    const { renderToCanvas } = await import('@storybook/preact/dist/entry-preview.mjs');
-
-    return renderToCanvas(ctx, element);
   }
 }

--- a/packages/@storybook/astro/src/integrations/react.ts
+++ b/packages/@storybook/astro/src/integrations/react.ts
@@ -1,0 +1,59 @@
+import type { Integration } from './base';
+import type { Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+
+export type Options = Pick<ViteReactPluginOptions, 'include' | 'exclude'>;
+
+export class ReactIntegration implements Integration {
+  readonly name = 'react';
+  readonly dependencies = ['@astrojs/react', '@storybook/react', 'react', 'react-dom'];
+  readonly options: Options;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+  }
+
+  async addRenderer(container: AstroContainer): Promise<void> {
+    // const mod = await import('@astrojs/react/server.js');
+
+    // container.addServerRenderer({
+    //   renderer: mod.default,
+    //   name: '@astrojs/react'
+    // });
+
+    // container.addClientRenderer({
+    //   name: '@astrojs/react',
+    //   entrypoint: '@astrojs/react/client.js'
+    // });
+
+    const { default: reactRenderer } = await import('@astrojs/react/server.js');
+
+    container.addServerRenderer({
+      renderer: reactRenderer,
+      name: '@astrojs/react'
+    });
+
+    container.addClientRenderer({
+      name: '@astrojs/react',
+      entrypoint: '@astrojs/react/client.js'
+    });
+  }
+
+  resolveClient(moduleName: string): string | undefined {
+    if (moduleName.startsWith('@astrojs/react/client')) {
+      return `/@id/${moduleName}`;
+    }
+  }
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/react');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+
+    return renderToCanvas(ctx, element);
+  }
+}

--- a/packages/@storybook/astro/src/integrations/react.ts
+++ b/packages/@storybook/astro/src/integrations/react.ts
@@ -1,6 +1,5 @@
 import type { Integration } from './base';
 import type { Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
-import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Pick<ViteReactPluginOptions, 'include' | 'exclude'>;
 
@@ -8,6 +7,7 @@ export class ReactIntegration implements Integration {
   readonly name = 'react';
   readonly dependencies = ['@astrojs/react', '@storybook/react', 'react', 'react-dom'];
   readonly options: Options;
+  readonly storybookEntryPreview = '@storybook/react/dist/entry-preview.mjs';
 
   readonly renderer = {
     server: {
@@ -34,15 +34,5 @@ export class ReactIntegration implements Integration {
     const framework = await import('@astrojs/react');
 
     return framework.default(this.options);
-  }
-
-  async loadIntegration2() {
-    return Promise.all([import('@astrojs/react'), import('@astrojs/react/server.js')]);
-  }
-
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement): Promise<void> {
-    const { renderToCanvas } = await import('@storybook/react/dist/entry-preview.mjs');
-
-    return renderToCanvas(ctx, element);
   }
 }

--- a/packages/@storybook/astro/src/integrations/react.ts
+++ b/packages/@storybook/astro/src/integrations/react.ts
@@ -1,6 +1,5 @@
 import type { Integration } from './base';
 import type { Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 
 export type Options = Pick<ViteReactPluginOptions, 'include' | 'exclude'>;
@@ -10,34 +9,19 @@ export class ReactIntegration implements Integration {
   readonly dependencies = ['@astrojs/react', '@storybook/react', 'react', 'react-dom'];
   readonly options: Options;
 
-  constructor(options: Options = {}) {
-    this.options = options;
-  }
-
-  async addRenderer(container: AstroContainer): Promise<void> {
-    // const mod = await import('@astrojs/react/server.js');
-
-    // container.addServerRenderer({
-    //   renderer: mod.default,
-    //   name: '@astrojs/react'
-    // });
-
-    // container.addClientRenderer({
-    //   name: '@astrojs/react',
-    //   entrypoint: '@astrojs/react/client.js'
-    // });
-
-    const { default: reactRenderer } = await import('@astrojs/react/server.js');
-
-    container.addServerRenderer({
-      renderer: reactRenderer,
-      name: '@astrojs/react'
-    });
-
-    container.addClientRenderer({
+  readonly renderer = {
+    server: {
+      name: '@astrojs/react',
+      entrypoint: '@astrojs/react/server.js'
+    },
+    client: {
       name: '@astrojs/react',
       entrypoint: '@astrojs/react/client.js'
-    });
+    }
+  };
+
+  constructor(options: Options = {}) {
+    this.options = options;
   }
 
   resolveClient(moduleName: string): string | undefined {
@@ -52,7 +36,12 @@ export class ReactIntegration implements Integration {
     return framework.default(this.options);
   }
 
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+  async loadIntegration2() {
+    return Promise.all([import('@astrojs/react'), import('@astrojs/react/server.js')]);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement): Promise<void> {
+    const { renderToCanvas } = await import('@storybook/react/dist/entry-preview.mjs');
 
     return renderToCanvas(ctx, element);
   }

--- a/packages/@storybook/astro/src/integrations/solid.ts
+++ b/packages/@storybook/astro/src/integrations/solid.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { RenderContext } from 'storybook/internal/types';
 import type { Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
 
 export type Options = Pick<ViteSolidPluginOptions, 'include' | 'exclude'>;
@@ -8,6 +7,7 @@ export class SolidIntegration implements Integration {
   readonly name = 'solid';
   readonly dependencies = ['@astrojs/solid-js', 'storybook-solidjs', 'solid-js'];
   readonly options: Options;
+  readonly storybookEntryPreview = 'storybook-solidjs/dist/entry-preview.mjs';
   readonly renderer = {
     server: {
       name: '@astrojs/solid-js',
@@ -33,11 +33,5 @@ export class SolidIntegration implements Integration {
     const framework = await import('@astrojs/solid-js');
 
     return framework.default(this.options);
-  }
-
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
-    const { renderToCanvas } = await import('storybook-solidjs/dist/entry-preview.mjs');
-
-    return renderToCanvas(ctx, element);
   }
 }

--- a/packages/@storybook/astro/src/integrations/solid.ts
+++ b/packages/@storybook/astro/src/integrations/solid.ts
@@ -1,0 +1,51 @@
+import type { Integration } from './base';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+import type { Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
+
+export type Options = Pick<ViteSolidPluginOptions, 'include' | 'exclude'>;
+
+export class SolidIntegration implements Integration {
+  readonly name = 'solid';
+  readonly dependencies = ['@astrojs/solid-js', 'storybook-solidjs', 'solid-js'];
+  readonly options: Options;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+  }
+
+  async addRenderer(container: AstroContainer): Promise<void> {
+    const mod = await import('@astrojs/solid-js/server.js');
+
+    container.addServerRenderer({
+      name: '@astrojs/solid-js',
+      renderer: {
+        ...mod.default,
+        name: '@astrojs/solid-js'
+      }
+    });
+
+    container.addClientRenderer({
+      name: '@astrojs/solid-js',
+      entrypoint: '@astrojs/solid-js/client.js'
+    });
+  }
+
+  resolveClient(moduleName: string): string | undefined {
+    if (moduleName.startsWith('@astrojs/solid-js/client')) {
+      return `/@id/${moduleName}`;
+    }
+  }
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/solid-js');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+    const { renderToCanvas } = await import('storybook-solidjs/dist/entry-preview.mjs');
+
+    return renderToCanvas(ctx, element);
+  }
+}

--- a/packages/@storybook/astro/src/integrations/solid.ts
+++ b/packages/@storybook/astro/src/integrations/solid.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 import type { Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
 
@@ -9,26 +8,19 @@ export class SolidIntegration implements Integration {
   readonly name = 'solid';
   readonly dependencies = ['@astrojs/solid-js', 'storybook-solidjs', 'solid-js'];
   readonly options: Options;
+  readonly renderer = {
+    server: {
+      name: '@astrojs/solid-js',
+      entrypoint: '@astrojs/solid-js/server.js'
+    },
+    client: {
+      name: '@astrojs/solid-js',
+      entrypoint: '@astrojs/solid-js/client.js'
+    }
+  };
 
   constructor(options: Options = {}) {
     this.options = options;
-  }
-
-  async addRenderer(container: AstroContainer): Promise<void> {
-    const mod = await import('@astrojs/solid-js/server.js');
-
-    container.addServerRenderer({
-      name: '@astrojs/solid-js',
-      renderer: {
-        ...mod.default,
-        name: '@astrojs/solid-js'
-      }
-    });
-
-    container.addClientRenderer({
-      name: '@astrojs/solid-js',
-      entrypoint: '@astrojs/solid-js/client.js'
-    });
   }
 
   resolveClient(moduleName: string): string | undefined {

--- a/packages/@storybook/astro/src/integrations/svelte.ts
+++ b/packages/@storybook/astro/src/integrations/svelte.ts
@@ -1,9 +1,8 @@
 import type { Integration } from './base';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 import type { Options as _foo, PluginOptions, SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 
-// Using Omit with empty string to preserve index signature 
+// Using Omit with empty string to preserve index signature
 // capabilities while maintaining the structure of the original types
 export type Options = Omit<PluginOptions, ''> & Omit<SvelteConfig, 'vitePlugin'>;
 
@@ -16,22 +15,19 @@ export class SvelteIntegration implements Integration {
   readonly dependencies = ['@astrojs/svelte', '@storybook/svelte', 'svelte'];
   readonly options: Options;
 
-  constructor(options: Options = DEFAULT_OPTIONS) {
-    this.options = options;
-  }
-
-  async addRenderer(container: AstroContainer): Promise<void> {
-    const mod = await import('@astrojs/svelte/server.js');
-
-    container.addServerRenderer({
-      renderer: mod.default,
+  readonly renderer = {
+    server: {
+      entrypoint: '@astrojs/svelte/server.js',
       name: '@astrojs/svelte'
-    });
-
-    container.addClientRenderer({
+    },
+    client: {
       name: '@astrojs/svelte',
       entrypoint: '@astrojs/svelte/client.js'
-    });
+    }
+  };
+
+  constructor(options: Options = DEFAULT_OPTIONS) {
+    this.options = options;
   }
 
   resolveClient(moduleName: string): string | undefined {

--- a/packages/@storybook/astro/src/integrations/svelte.ts
+++ b/packages/@storybook/astro/src/integrations/svelte.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { RenderContext } from 'storybook/internal/types';
 import type { Options as _foo, PluginOptions, SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 
 // Using Omit with empty string to preserve index signature
@@ -14,7 +13,7 @@ export class SvelteIntegration implements Integration {
   readonly name = 'svelte';
   readonly dependencies = ['@astrojs/svelte', '@storybook/svelte', 'svelte'];
   readonly options: Options;
-
+  readonly storybookEntryPreview = '@storybook/svelte/dist/entry-preview.mjs';
   readonly renderer = {
     server: {
       entrypoint: '@astrojs/svelte/server.js',
@@ -40,12 +39,5 @@ export class SvelteIntegration implements Integration {
     const framework = await import('@astrojs/svelte');
 
     return framework.default(this.options);
-  }
-
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
-    // @ts-expect-error Missing declaration
-    const { renderToCanvas } = await import('@storybook/svelte/dist/entry-preview.mjs');
-
-    return renderToCanvas(ctx, element);
   }
 }

--- a/packages/@storybook/astro/src/integrations/svelte.ts
+++ b/packages/@storybook/astro/src/integrations/svelte.ts
@@ -1,0 +1,55 @@
+import type { Integration } from './base';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+import type { Options as _foo, PluginOptions, SvelteConfig } from '@sveltejs/vite-plugin-svelte';
+
+// Using Omit with empty string to preserve index signature 
+// capabilities while maintaining the structure of the original types
+export type Options = Omit<PluginOptions, ''> & Omit<SvelteConfig, 'vitePlugin'>;
+
+const DEFAULT_OPTIONS: Options = {
+  extensions: ['.svelte']
+};
+
+export class SvelteIntegration implements Integration {
+  readonly name = 'svelte';
+  readonly dependencies = ['@astrojs/svelte', '@storybook/svelte', 'svelte'];
+  readonly options: Options;
+
+  constructor(options: Options = DEFAULT_OPTIONS) {
+    this.options = options;
+  }
+
+  async addRenderer(container: AstroContainer): Promise<void> {
+    const mod = await import('@astrojs/svelte/server.js');
+
+    container.addServerRenderer({
+      renderer: mod.default,
+      name: '@astrojs/svelte'
+    });
+
+    container.addClientRenderer({
+      name: '@astrojs/svelte',
+      entrypoint: '@astrojs/svelte/client.js'
+    });
+  }
+
+  resolveClient(moduleName: string): string | undefined {
+    if (moduleName.startsWith('@astrojs/svelte/client')) {
+      return `/@id/${moduleName}`;
+    }
+  }
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/svelte');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+    // @ts-expect-error Missing declaration
+    const { renderToCanvas } = await import('@storybook/svelte/dist/entry-preview.mjs');
+
+    return renderToCanvas(ctx, element);
+  }
+}

--- a/packages/@storybook/astro/src/integrations/vue.ts
+++ b/packages/@storybook/astro/src/integrations/vue.ts
@@ -1,0 +1,57 @@
+import type { Integration } from './base';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { RenderContext } from 'storybook/internal/types';
+import type { Options as VueOptions } from '@vitejs/plugin-vue';
+import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
+
+export type Options = Pick<VueOptions, 'include' | 'exclude'> & {
+  jsx?: boolean | VueJsxOptions;
+};
+
+const DEFAULT_OPTIONS: Options = {
+  include: ['**/*.vue']
+};
+
+export class VueIntegration implements Integration {
+  readonly name = 'vue';
+  // FIXME: Add missing dependencies
+  readonly dependencies = ['@astrojs/vue', '@storybook/vue3'];
+  readonly options: Options;
+
+  constructor(options: Options = DEFAULT_OPTIONS) {
+    this.options = options;
+  }
+
+  async addRenderer(container: AstroContainer): Promise<void> {
+    const mod = await import('@astrojs/vue/server.js');
+
+    container.addServerRenderer({
+      renderer: mod.default,
+      name: '@astrojs/vue'
+    });
+
+    container.addClientRenderer({
+      name: '@astrojs/vue',
+      entrypoint: '@astrojs/vue/client.js'
+    });
+  }
+
+  resolveClient(moduleName: string): string | undefined {
+    if (moduleName.startsWith('@astrojs/vue/client')) {
+      return `/@id/${moduleName}`;
+    }
+  }
+
+  async loadIntegration() {
+    const framework = await import('@astrojs/vue');
+
+    return framework.default(this.options);
+  }
+
+  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
+    // @ts-expect-error Missing declaration
+    const { renderToCanvas } = await import('@storybook/vue3/dist/entry-preview.mjs');
+
+    return renderToCanvas(ctx, element);
+  }
+}

--- a/packages/@storybook/astro/src/integrations/vue.ts
+++ b/packages/@storybook/astro/src/integrations/vue.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { RenderContext } from 'storybook/internal/types';
 import type { Options as VueOptions } from '@vitejs/plugin-vue';
 import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
 
@@ -16,6 +15,7 @@ export class VueIntegration implements Integration {
   // FIXME: Add missing dependencies
   readonly dependencies = ['@astrojs/vue', '@storybook/vue3'];
   readonly options: Options;
+  readonly storybookEntryPreview = '@storybook/vue3/dist/entry-preview.mjs';
 
   readonly renderer = {
     server: {
@@ -42,12 +42,5 @@ export class VueIntegration implements Integration {
     const framework = await import('@astrojs/vue');
 
     return framework.default(this.options);
-  }
-
-  async renderToCanvas(ctx: RenderContext, element: HTMLElement) {
-    // @ts-expect-error Missing declaration
-    const { renderToCanvas } = await import('@storybook/vue3/dist/entry-preview.mjs');
-
-    return renderToCanvas(ctx, element);
   }
 }

--- a/packages/@storybook/astro/src/integrations/vue.ts
+++ b/packages/@storybook/astro/src/integrations/vue.ts
@@ -1,5 +1,4 @@
 import type { Integration } from './base';
-import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { RenderContext } from 'storybook/internal/types';
 import type { Options as VueOptions } from '@vitejs/plugin-vue';
 import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
@@ -18,22 +17,19 @@ export class VueIntegration implements Integration {
   readonly dependencies = ['@astrojs/vue', '@storybook/vue3'];
   readonly options: Options;
 
-  constructor(options: Options = DEFAULT_OPTIONS) {
-    this.options = options;
-  }
-
-  async addRenderer(container: AstroContainer): Promise<void> {
-    const mod = await import('@astrojs/vue/server.js');
-
-    container.addServerRenderer({
-      renderer: mod.default,
-      name: '@astrojs/vue'
-    });
-
-    container.addClientRenderer({
+  readonly renderer = {
+    server: {
+      name: '@astrojs/vue',
+      entrypoint: '@astrojs/vue/server.js'
+    },
+    client: {
       name: '@astrojs/vue',
       entrypoint: '@astrojs/vue/client.js'
-    });
+    }
+  };
+
+  constructor(options: Options = DEFAULT_OPTIONS) {
+    this.options = options;
   }
 
   resolveClient(moduleName: string): string | undefined {

--- a/packages/@storybook/astro/src/middleware.ts
+++ b/packages/@storybook/astro/src/middleware.ts
@@ -1,5 +1,6 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { SupportedFramework } from './types';
+import type { Integration } from './integrations';
 
 async function attachRenderers(container: AstroContainer, integrations: SupportedFramework[]) {
   if (integrations.includes('react')) {
@@ -44,58 +45,98 @@ async function attachRenderers(container: AstroContainer, integrations: Supporte
     });
   }
 
-  if (integrations.includes('solid')) {
-    const { default: solidRenderer } = await import('@astrojs/solid-js/server.js');
+  // if (integrations.includes('solid')) {
+  //   const { default: solidRenderer } = await import('@astrojs/solid-js/server.js');
 
-    container.addServerRenderer({
-      name: '@astrojs/solid-js',
-      renderer: {
-        ...solidRenderer,
-        name: '@astrojs/solid-js'
-      }
-    });
+  //   container.addServerRenderer({
+  //     name: '@astrojs/solid-js',
+  //     renderer: {
+  //       ...solidRenderer,
+  //       name: '@astrojs/solid-js'
+  //     }
+  //   });
 
-    container.addClientRenderer({
-      name: '@astrojs/solid-js',
-      entrypoint: '@astrojs/solid-js/client.js'
-    });
-  }
+  //   container.addClientRenderer({
+  //     name: '@astrojs/solid-js',
+  //     entrypoint: '@astrojs/solid-js/client.js'
+  //   });
+  // }
 
-  if (integrations.includes('preact')) {
-    const { default: preactRenderer } = await import('@astrojs/preact/server.js');
+  // if (integrations.includes('preact')) {
+  //   const { default: preactRenderer } = await import('@astrojs/preact/server.js');
 
-    container.addServerRenderer({
-      name: '@astrojs/preact',
-      renderer: preactRenderer
-    });
+  //   container.addServerRenderer({
+  //     name: '@astrojs/preact',
+  //     renderer: preactRenderer
+  //   });
 
-    container.addClientRenderer({
-      name: '@astrojs/preact',
-      entrypoint: '@astrojs/preact/client.js'
-    });
-  }
+  //   container.addClientRenderer({
+  //     name: '@astrojs/preact',
+  //     entrypoint: '@astrojs/preact/client.js'
+  //   });
+  // }
 }
 
-export async function handlerFactory(integrations: SupportedFramework[]) {
+export async function handlerFactory(
+  integrations: SupportedFramework[],
+  integrations2: Integration[]
+) {
   const container = await AstroContainer.create({
     // Somewhat hacky way to force client-side Storybook's Vite to resolve modules properly
     resolve: async (s) => {
-      if (
-        s.startsWith('astro:scripts') ||
-        s.startsWith('@astrojs/react/client') ||
-        s.startsWith('@astrojs/solid-js/client') ||
-        s.startsWith('@astrojs/preact/client') ||
-        s.startsWith('@astrojs/svelte/client') ||
-        s.startsWith('@astrojs/vue/client')
-      ) {
+      if (s.startsWith('astro:scripts')) {
         return `/@id/${s}`;
+      }
+
+      for (const integration of integrations2) {
+        const resolution = integration.resolveClient(s);
+
+        if (resolution) {
+          return resolution;
+        }
       }
 
       return s;
     }
+    // resolve: async (s) => {
+    //   if (
+    //     s.startsWith('astro:scripts') ||
+    //     s.startsWith('@astrojs/react/client') ||
+    //     s.startsWith('@astrojs/solid-js/client') ||
+    //     s.startsWith('@astrojs/preact/client') ||
+    //     s.startsWith('@astrojs/svelte/client') ||
+    //     s.startsWith('@astrojs/vue/client')
+    //   ) {
+    //     return `/@id/${s}`;
+    //   }
+
+    //   return s;
+    // }
   });
 
-  await attachRenderers(container, integrations);
+  // await Promise.all(integrations.map(integration => {
+  //   return integration.addRenderer(container);
+  // }));
+  const int2 = [
+    // 'alpine',
+    // 'svelte',
+    // 'preact',
+    'vue',
+    'react',
+    // 'solid'
+  ];
+
+  await attachRenderers(container, int2);
+
+  await Promise.all(
+    integrations2
+      .filter((integration) => !int2.includes(integration.name))
+      .map((integration) => {
+        console.log(`new way to load ${integration.name}`);
+
+        return integration.addRenderer(container);
+      })
+  );
 
   type HandlerProps = {
     component: string;

--- a/packages/@storybook/astro/src/middleware.ts
+++ b/packages/@storybook/astro/src/middleware.ts
@@ -1,86 +1,10 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import type { SupportedFramework } from './types';
 import type { Integration } from './integrations';
+import type { $FIXME } from './types';
 
-async function attachRenderers(container: AstroContainer, integrations: SupportedFramework[]) {
-  if (integrations.includes('react')) {
-    const { default: reactRenderer } = await import('@astrojs/react/server.js');
+type ViteLoadModuleFn = (modulePath: string) => Promise<Record<string, unknown>>;
 
-    container.addServerRenderer({
-      renderer: reactRenderer,
-      name: '@astrojs/react'
-    });
-
-    container.addClientRenderer({
-      name: '@astrojs/react',
-      entrypoint: '@astrojs/react/client.js'
-    });
-  }
-
-  if (integrations.includes('svelte')) {
-    const { default: svelteRenderer } = await import('@astrojs/svelte/server.js');
-
-    container.addServerRenderer({
-      renderer: svelteRenderer,
-      name: '@astrojs/svelte'
-    });
-
-    container.addClientRenderer({
-      name: '@astrojs/svelte',
-      entrypoint: '@astrojs/svelte/client.js'
-    });
-  }
-
-  if (integrations.includes('vue')) {
-    const { default: vueRenderer } = await import('@astrojs/vue/server.js');
-
-    container.addServerRenderer({
-      renderer: vueRenderer,
-      name: '@astrojs/vue'
-    });
-
-    container.addClientRenderer({
-      name: '@astrojs/vue',
-      entrypoint: '@astrojs/vue/client.js'
-    });
-  }
-
-  // if (integrations.includes('solid')) {
-  //   const { default: solidRenderer } = await import('@astrojs/solid-js/server.js');
-
-  //   container.addServerRenderer({
-  //     name: '@astrojs/solid-js',
-  //     renderer: {
-  //       ...solidRenderer,
-  //       name: '@astrojs/solid-js'
-  //     }
-  //   });
-
-  //   container.addClientRenderer({
-  //     name: '@astrojs/solid-js',
-  //     entrypoint: '@astrojs/solid-js/client.js'
-  //   });
-  // }
-
-  // if (integrations.includes('preact')) {
-  //   const { default: preactRenderer } = await import('@astrojs/preact/server.js');
-
-  //   container.addServerRenderer({
-  //     name: '@astrojs/preact',
-  //     renderer: preactRenderer
-  //   });
-
-  //   container.addClientRenderer({
-  //     name: '@astrojs/preact',
-  //     entrypoint: '@astrojs/preact/client.js'
-  //   });
-  // }
-}
-
-export async function handlerFactory(
-  integrations: SupportedFramework[],
-  integrations2: Integration[]
-) {
+export async function handlerFactory(integrations: Integration[], loadModule: ViteLoadModuleFn) {
   const container = await AstroContainer.create({
     // Somewhat hacky way to force client-side Storybook's Vite to resolve modules properly
     resolve: async (s) => {
@@ -88,7 +12,7 @@ export async function handlerFactory(
         return `/@id/${s}`;
       }
 
-      for (const integration of integrations2) {
+      for (const integration of integrations) {
         const resolution = integration.resolveClient(s);
 
         if (resolution) {
@@ -98,44 +22,30 @@ export async function handlerFactory(
 
       return s;
     }
-    // resolve: async (s) => {
-    //   if (
-    //     s.startsWith('astro:scripts') ||
-    //     s.startsWith('@astrojs/react/client') ||
-    //     s.startsWith('@astrojs/solid-js/client') ||
-    //     s.startsWith('@astrojs/preact/client') ||
-    //     s.startsWith('@astrojs/svelte/client') ||
-    //     s.startsWith('@astrojs/vue/client')
-    //   ) {
-    //     return `/@id/${s}`;
-    //   }
-
-    //   return s;
-    // }
   });
 
-  // await Promise.all(integrations.map(integration => {
-  //   return integration.addRenderer(container);
-  // }));
-  const int2 = [
-    // 'alpine',
-    // 'svelte',
-    // 'preact',
-    'vue',
-    'react',
-    // 'solid'
-  ];
-
-  await attachRenderers(container, int2);
-
   await Promise.all(
-    integrations2
-      .filter((integration) => !int2.includes(integration.name))
-      .map((integration) => {
-        console.log(`new way to load ${integration.name}`);
+    integrations.map(async (integration) => {
+      if (integration.renderer.server) {
+        const renderer = await loadModule(integration.renderer.server.entrypoint);
 
-        return integration.addRenderer(container);
-      })
+        container.addServerRenderer({
+          name: integration.renderer.server.name,
+          renderer:
+            integration.name === 'solid'
+              ? // Solid needs special handling
+                {
+                  ...(renderer.default as $FIXME),
+                  name: integration.renderer.server.name
+                }
+              : renderer.default
+        });
+      }
+
+      if (integration.renderer.client) {
+        container.addClientRenderer(integration.renderer.client);
+      }
+    })
   );
 
   type HandlerProps = {

--- a/packages/@storybook/astro/src/middleware.ts
+++ b/packages/@storybook/astro/src/middleware.ts
@@ -1,6 +1,12 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { Integration } from './integrations';
-import { addRenderers } from 'virtual:astro-renderers';
+import { addRenderers } from 'virtual:astro-container-renderers';
+
+export type HandlerProps = {
+  component: string;
+  args?: Record<string, unknown>;
+  slots?: Record<string, unknown>;
+};
 
 export async function handlerFactory(integrations: Integration[]) {
   const container = await AstroContainer.create({
@@ -23,12 +29,6 @@ export async function handlerFactory(integrations: Integration[]) {
   });
 
   addRenderers(container);
-  
-  type HandlerProps = {
-    component: string;
-    args?: Record<string, unknown>;
-    slots?: Record<string, unknown>;
-  };
 
   return async function handler(data: HandlerProps) {
     const { default: Component } = await import(/* @vite-ignore */ data.component);

--- a/packages/@storybook/astro/src/preset.ts
+++ b/packages/@storybook/astro/src/preset.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "node:path";
 import type { StorybookConfigVite, FrameworkOptions } from "./types";
 import { vitePluginStorybookAstroMiddleware } from "./viteStorybookAstroMiddlewarePlugin";
 import { mergeWithAstroConfig } from "./vitePluginAstro";
+import { react, solid, svelte, vue, preact, alpinejs } from "./integrations";
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -16,9 +17,24 @@ export const viteFinal: StorybookConfigVite["viteFinal"] = async (
   config,
   { presets }
 ) => {
+  const integrations = [
+    react({
+      include: ['**/react/*'],
+    }),
+    solid({
+      include: ['**/solid/*'],
+    }),
+    preact({
+      include: ['**/preact/*'],
+    }),
+    vue(),
+    svelte(),
+    alpinejs(),
+  ];
+
   const options = await presets.apply<FrameworkOptions>("frameworkOptions");
   const { vitePlugin: storybookAstroMiddlewarePlugin, viteConfig } =
-    await vitePluginStorybookAstroMiddleware(options);
+    await vitePluginStorybookAstroMiddleware(options, integrations);
 
   if (!config.plugins) {
     config.plugins = [];
@@ -26,7 +42,7 @@ export const viteFinal: StorybookConfigVite["viteFinal"] = async (
 
   config.plugins.push(storybookAstroMiddlewarePlugin, ...viteConfig.plugins);
 
-  const finalConfig = await mergeWithAstroConfig(config);
+  const finalConfig = await mergeWithAstroConfig(config, integrations);
 
   return finalConfig;
 };

--- a/packages/@storybook/astro/src/preset.ts
+++ b/packages/@storybook/astro/src/preset.ts
@@ -1,40 +1,22 @@
-import { dirname, join } from "node:path";
-import type { StorybookConfigVite, FrameworkOptions } from "./types";
-import { vitePluginStorybookAstroMiddleware } from "./viteStorybookAstroMiddlewarePlugin";
-import { mergeWithAstroConfig } from "./vitePluginAstro";
-import { react, solid, svelte, vue, preact, alpinejs } from "./integrations";
+import { dirname, join } from 'node:path';
+import type { StorybookConfigVite, FrameworkOptions } from './types';
+import { vitePluginStorybookAstroMiddleware } from './viteStorybookAstroMiddlewarePlugin';
+import { mergeWithAstroConfig } from './vitePluginAstro';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dirname(require.resolve(join(input, "package.json"))) as any;
+  dirname(require.resolve(join(input, 'package.json'))) as any;
 
 export const core = {
-  builder: getAbsolutePath("@storybook/builder-vite"),
-  renderer: getAbsolutePath("@storybook/astro-renderer"),
+  builder: getAbsolutePath('@storybook/builder-vite'),
+  renderer: getAbsolutePath('@storybook/astro-renderer')
 };
 
-export const viteFinal: StorybookConfigVite["viteFinal"] = async (
-  config,
-  { presets }
-) => {
-  const integrations = [
-    react({
-      include: ['**/react/*'],
-    }),
-    solid({
-      include: ['**/solid/*'],
-    }),
-    preact({
-      include: ['**/preact/*'],
-    }),
-    vue(),
-    svelte(),
-    alpinejs(),
-  ];
+export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { presets }) => {
 
-  const options = await presets.apply<FrameworkOptions>("frameworkOptions");
+  const options = await presets.apply<FrameworkOptions>('frameworkOptions');
   const { vitePlugin: storybookAstroMiddlewarePlugin, viteConfig } =
-    await vitePluginStorybookAstroMiddleware(options, integrations);
+    await vitePluginStorybookAstroMiddleware(options);
 
   if (!config.plugins) {
     config.plugins = [];
@@ -42,7 +24,7 @@ export const viteFinal: StorybookConfigVite["viteFinal"] = async (
 
   config.plugins.push(storybookAstroMiddlewarePlugin, ...viteConfig.plugins);
 
-  const finalConfig = await mergeWithAstroConfig(config, integrations);
+  const finalConfig = await mergeWithAstroConfig(config, options.integrations);
 
   return finalConfig;
 };

--- a/packages/@storybook/astro/src/preset.ts
+++ b/packages/@storybook/astro/src/preset.ts
@@ -33,11 +33,12 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { pres
 };
 
 function storybookRenderersPlugin(integrations: Integration[]) {
-  const virtualModuleId = 'virtual:storybook-renderers';
-  const resolvedVirtualModuleId = '\0' + virtualModuleId;
+  const name = 'storybook-renderers';
+  const virtualModuleId = `virtual:${name}`;
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
 
   return {
-    name: 'virtual-module-plugin',
+    name,
 
     resolveId(id: string) {
       if (id === virtualModuleId) {

--- a/packages/@storybook/astro/src/types.ts
+++ b/packages/@storybook/astro/src/types.ts
@@ -1,20 +1,15 @@
 import type { CompatibleString, Options } from 'storybook/internal/types';
 import type { InlineConfig } from 'vite';
+import type { Integration } from './integrations';
 
 type FrameworkName = CompatibleString<'@storybook/astro'>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type $FIXME = any;
 
-export type SupportedFramework =
-  | 'react'
-  | 'svelte'
-  | 'vue'
-  | 'solid'
-  | 'preact';
-
+export type { Integration };
 export type FrameworkOptions = {
-  integrations: SupportedFramework[];
+  integrations: Integration[];
 };
 
 type StorybookConfigFramework = {

--- a/packages/@storybook/astro/src/virtual.d.ts
+++ b/packages/@storybook/astro/src/virtual.d.ts
@@ -1,0 +1,7 @@
+declare module 'virtual:astro-container-renderers' {
+  import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+
+  export function addRenderers(container: AstroContainer): void;
+}
+
+declare module 'virtual:storybook-renderer-fallback' {}

--- a/packages/@storybook/astro/src/viteAstroContainerRenderersPlugin.ts
+++ b/packages/@storybook/astro/src/viteAstroContainerRenderersPlugin.ts
@@ -1,0 +1,84 @@
+import type { Integration } from './integrations';
+
+export function viteAstroContainerRenderersPlugin(integrations: Integration[]) {
+  const name = 'astro-container-renderers';
+  const virtualModuleId = `virtual:${name}`;
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+  return {
+    name,
+
+    resolveId(id: string) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+
+    load(id: string) {
+      if (id === resolvedVirtualModuleId) {
+        const importStatements = buildImportStatements(integrations);
+
+        const code = `
+          ${importStatements}
+          export function addRenderers(container) {
+            ${integrations.map((integration) => buildServerRenderer(integration) + '\n' + buildClientRenderer(integration)).join('\n')}
+          }
+        `;
+
+        return code;
+      }
+    }
+  };
+}
+
+function buildImportStatements(integrations: Integration[]) {
+  return integrations
+    .filter((integration) => integration.renderer.server)
+    .map(
+      (integration) =>
+        `import ${integration.name}Renderer from '${integration.renderer.server?.entrypoint}';`
+    )
+    .join('\n');
+}
+
+function buildServerRenderer(integration: Integration) {
+  const serverRenderer = integration.renderer.server;
+
+  if (!serverRenderer) {
+    return '';
+  }
+
+  if (integration.name === 'solid') {
+    return `
+      container.addServerRenderer({
+        name: '${serverRenderer.name}',
+        renderer: {
+          ...${integration.name}Renderer,
+          name: '${serverRenderer.name}'
+        }
+      });
+    `;
+  }
+
+  return `
+    container.addServerRenderer({
+      name: '${serverRenderer.name}',
+      renderer: ${integration.name}Renderer
+    });
+  `;
+}
+
+function buildClientRenderer(integration: Integration) {
+  const clientRenderer = integration.renderer.client;
+
+  if (clientRenderer) {
+    return `
+      container.addClientRenderer({
+        name: '${clientRenderer.name}',
+        renderer: '${clientRenderer.entrypoint}'
+      });
+    `;
+  }
+
+  return '';
+}

--- a/packages/@storybook/astro/src/viteAstroContainerRenderersPlugin.ts
+++ b/packages/@storybook/astro/src/viteAstroContainerRenderersPlugin.ts
@@ -75,7 +75,7 @@ function buildClientRenderer(integration: Integration) {
     return `
       container.addClientRenderer({
         name: '${clientRenderer.name}',
-        renderer: '${clientRenderer.entrypoint}'
+        entrypoint: '${clientRenderer.entrypoint}'
       });
     `;
   }

--- a/packages/@storybook/astro/src/vitePluginAstro.ts
+++ b/packages/@storybook/astro/src/vitePluginAstro.ts
@@ -1,39 +1,48 @@
-import { mergeConfig, type InlineConfig } from "vite";
+import { mergeConfig, type InlineConfig } from 'vite';
+import type { Integration } from './integrations';
 
 const ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK = [
-  "@astro/plugin-actions",
-  "@astrojs/vite-plugin-astro-ssr-manifest",
-  "astro-content-virtual-mod-plugin",
-  "astro:actions",
-  "astro:assets:esm",
-  "astro:assets",
-  "astro:build:normal",
-  "astro:container",
-  "astro:content-asset-propagation",
-  "astro:content-imports",
-  "astro:content-listen",
-  "astro:dev-toolbar",
-  "astro:head-metadata",
-  "astro:html",
-  "astro:i18n",
-  "astro:integration-container",
-  "astro:jsx",
-  "astro:markdown",
-  "astro:postprocess",
-  "astro:prefetch",
-  "astro:scanner",
-  "astro:scripts:page-ssr",
-  "astro:server",
-  "astro:vite-plugin-env",
-  "astro:vite-plugin-file-url",
+  '@astro/plugin-actions',
+  '@astrojs/vite-plugin-astro-ssr-manifest',
+  'astro-content-virtual-mod-plugin',
+  'astro:actions',
+  'astro:assets:esm',
+  'astro:assets',
+  'astro:build:normal',
+  'astro:container',
+  'astro:content-asset-propagation',
+  'astro:content-imports',
+  'astro:content-listen',
+  'astro:dev-toolbar',
+  'astro:head-metadata',
+  'astro:html',
+  'astro:i18n',
+  'astro:integration-container',
+  'astro:jsx',
+  'astro:markdown',
+  'astro:postprocess',
+  'astro:prefetch',
+  'astro:scanner',
+  'astro:scripts:page-ssr',
+  'astro:server',
+  'astro:vite-plugin-env',
+  'astro:vite-plugin-file-url'
 ];
 
-export async function mergeWithAstroConfig(config: InlineConfig) {
-  const { getViteConfig } = await import("astro/config");
+export async function mergeWithAstroConfig(config: InlineConfig, integration: Integration[]) {
+  const { getViteConfig } = await import('astro/config');
 
-  const astroConfig = await getViteConfig({})({
-    mode: "development",
-    command: "serve",
+  const astroConfig = await getViteConfig(
+    {},
+    {
+      configFile: false,
+      integrations: await Promise.all(
+        integration.map((integration) => integration.loadIntegration())
+      )
+    }
+  )({
+    mode: 'development',
+    command: 'serve'
   });
 
   const filteredPlugins = astroConfig
@@ -41,14 +50,12 @@ export async function mergeWithAstroConfig(config: InlineConfig) {
     .filter(
       (plugin) =>
         plugin &&
-        "name" in plugin &&
-        !ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK.includes(
-          plugin.name
-        )
+        'name' in plugin &&
+        !ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK.includes(plugin.name)
     );
 
   return mergeConfig(config, {
     ...astroConfig,
-    plugins: filteredPlugins,
+    plugins: filteredPlugins
   });
 }

--- a/packages/@storybook/astro/src/vitePluginAstro.ts
+++ b/packages/@storybook/astro/src/vitePluginAstro.ts
@@ -29,7 +29,7 @@ const ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK = [
   'astro:vite-plugin-file-url'
 ];
 
-export async function mergeWithAstroConfig(config: InlineConfig, integration: Integration[]) {
+export async function mergeWithAstroConfig(config: InlineConfig, integrations: Integration[]) {
   const { getViteConfig } = await import('astro/config');
 
   const astroConfig = await getViteConfig(
@@ -37,7 +37,7 @@ export async function mergeWithAstroConfig(config: InlineConfig, integration: In
     {
       configFile: false,
       integrations: await Promise.all(
-        integration.map((integration) => integration.loadIntegration())
+        integrations.map((integration) => integration.loadIntegration())
       )
     }
   )({

--- a/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -1,24 +1,24 @@
 import { fileURLToPath } from 'node:url';
 import { createServer, type PluginOption } from 'vite';
-// import type { AstroInlineConfig } from 'astro';
 import type { RenderRequestMessage, RenderResponseMessage } from '@storybook/astro-renderer/types';
-import type { FrameworkOptions, SupportedFramework } from './types';
+import type { FrameworkOptions } from './types';
 import type { Integration } from './integrations';
 
-export async function vitePluginStorybookAstroMiddleware(
-  options: FrameworkOptions,
-  integrations: Integration[]
-) {
-  const viteServer = await createViteServer(options.integrations, integrations);
+export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptions) {
+  const viteServer = await createViteServer(options.integrations);
 
   const vitePlugin = {
     name: 'storybook-astro-middleware-plugin',
     async configureServer(server) {
       const filePath = fileURLToPath(new URL('./middleware', import.meta.url));
-      const mod = await viteServer.ssrLoadModule(filePath, {
+      const middleware = await viteServer.ssrLoadModule(filePath, {
         fixStacktrace: true
       });
-      const handler = await mod.handlerFactory(options.integrations, integrations);
+      const handler = await middleware.handlerFactory({
+        loadModule: (filePath: string) =>
+          viteServer.ssrLoadModule(filePath, { fixStacktrace: true }),
+        integrations: options.integrations
+      });
 
       server.ws.on('astro:render:request', async (data: RenderRequestMessage['data']) => {
         try {
@@ -53,13 +53,8 @@ export async function vitePluginStorybookAstroMiddleware(
   };
 }
 
-export async function createViteServer(
-  _oldIntegrations: SupportedFramework[],
-  integrations: Integration[]
-) {
+export async function createViteServer(integrations: Integration[]) {
   const { getViteConfig } = await import('astro/config');
-
-  // const mods = await loadIntegrations(integrations, integrations);
 
   const config = await getViteConfig(
     {},
@@ -79,43 +74,3 @@ export async function createViteServer(
 
   return viteServer;
 }
-
-// export async function loadIntegrations(
-//   integrations: SupportedFramework[],
-//   integrations2: Integration[]
-// ): Promise<AstroInlineConfig['integrations']> {
-//   const frameworkMap = {
-//     react: '@astrojs/react',
-//     preact: '@astrojs/preact',
-//     svelte: '@astrojs/svelte',
-//     vue: '@astrojs/vue',
-//     solid: '@astrojs/solid-js'
-//   };
-
-//   return Promise.all(
-//     integrations.map(async (integration) => {
-//       if (!frameworkMap[integration]) {
-//         console.error(`Unsupported framework: ${integration}`);
-
-//         return null;
-//       }
-
-//       const framework = await import(frameworkMap[integration]);
-
-//       if (['solid', 'preact'].includes(integration)) {
-//         return framework.default({
-//           // FIXME: Forward JSX frameworks config here
-//           include: [`**/${integration}/*`]
-//         });
-//       }
-
-//       if (['vue', 'svelte'].includes(integration)) {
-//         return framework.default({
-//           include: [`*.${integration}`]
-//         });
-//       }
-
-//       return framework.default();
-//     })
-//   ).then((result) => result.filter(Boolean));
-// }

--- a/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -67,8 +67,94 @@ export async function createViteServer(integrations: Integration[]) {
   const viteServer = await createServer({
     configFile: false,
     ...config,
-    plugins: config.plugins?.filter(Boolean)
+    plugins: [
+      ...(config.plugins?.filter(Boolean) ?? []),
+      astroRenderersPlugin(integrations)
+    ]
   });
 
   return viteServer;
+}
+
+function astroRenderersPlugin(integrations: Integration[]) {
+  const name = 'astro-renderers';
+  const virtualModuleId = `virtual:${name}`;
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+  return {
+    name,
+
+    resolveId(id: string) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+
+    load(id: string) {
+      if (id === resolvedVirtualModuleId) {
+        const importStatements = buildImportStatements(integrations);
+
+        return `
+          ${importStatements}
+          export function addRenderers(container) {
+            ${integrations.map(integration => buildServerRenderer(integration)).join('\n')}
+            ${integrations.map(integration => buildClientRenderer(integration)).join('\n')}
+          }
+        `;
+      }
+    }
+  };
+}
+
+function buildImportStatements(integrations: Integration[]) {
+  return integrations
+    .filter((integration) => integration.renderer.server)
+    .map(
+      (integration) =>
+        `import ${integration.name}Renderer from '${integration.renderer.server?.entrypoint}';`
+    )
+    .join('\n');
+}
+
+function buildServerRenderer(integration: Integration) {
+  const serverRenderer = integration.renderer.server;
+
+  if (!serverRenderer) {
+    return '';
+  }
+
+  if (integration.name === 'solid') {
+    return `
+      container.addServerRenderer({
+        name: '${serverRenderer.name}',
+        renderer: {
+          ...${integration.name}Renderer,
+          name: '${serverRenderer.name}'
+        }
+      });
+    `;
+  }
+
+  
+  return `
+    container.addServerRenderer({
+      name: '${serverRenderer.name}',
+      renderer: ${integration.name}Renderer
+    });
+  `;
+}
+
+function buildClientRenderer(integration: Integration) {
+  const clientRenderer = integration.renderer.client;
+  
+  if (clientRenderer) {
+    return `
+      container.addClientRenderer({
+        name: '${clientRenderer.name}',
+        renderer: '${clientRenderer.entrypoint}'
+      });
+      `;
+  }
+
+  return '';
 }

--- a/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook/astro/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -14,11 +14,9 @@ export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptio
       const middleware = await viteServer.ssrLoadModule(filePath, {
         fixStacktrace: true
       });
-      const handler = await middleware.handlerFactory({
-        loadModule: (filePath: string) =>
-          viteServer.ssrLoadModule(filePath, { fixStacktrace: true }),
-        integrations: options.integrations
-      });
+      const loadModule = (filePath: string) =>
+        viteServer.ssrLoadModule(filePath, { fixStacktrace: true });
+      const handler = await middleware.handlerFactory(options.integrations, loadModule);
 
       server.ws.on('astro:render:request', async (data: RenderRequestMessage['data']) => {
         try {

--- a/packages/@storybook/astro/src/viteStorybookRendererFallbackPlugin.ts
+++ b/packages/@storybook/astro/src/viteStorybookRendererFallbackPlugin.ts
@@ -1,0 +1,29 @@
+import type { Integration } from './integrations';
+
+export function viteStorybookRendererFallbackPlugin(integrations: Integration[]) {
+  const name = 'storybook-renderer-fallback';
+  const virtualModuleId = `virtual:${name}`;
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+  return {
+    name,
+
+    resolveId(id: string) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+
+    load(id: string) {
+      if (id === resolvedVirtualModuleId) {
+        return integrations
+          .filter((integration) => integration.storybookEntryPreview)
+          .map(
+            (integration) =>
+              `export * as ${integration.name} from '${integration.storybookEntryPreview}';`
+          )
+          .join('\n');
+      }
+    }
+  };
+}

--- a/src/stories/Preact.stories.js
+++ b/src/stories/Preact.stories.js
@@ -1,6 +1,9 @@
 import Counter from '../components/preact/Counter.jsx';
 
 export default {
+  parameters: {
+    renderer: 'preact',
+  },
   title: 'Preact/Counter',
   component: Counter,
   args: {},

--- a/src/stories/React.stories.js
+++ b/src/stories/React.stories.js
@@ -1,6 +1,9 @@
 import Counter from '../components/react/Counter.jsx';
 
 export default {
+  parameters: {
+    renderer: 'react'
+  },
   title: 'React/Counter',
   component: Counter,
   args: {},

--- a/src/stories/Solid.stories.js
+++ b/src/stories/Solid.stories.js
@@ -1,6 +1,9 @@
 import Counter from '../components/solid/Counter.jsx';
 
 export default {
+  parameters: {
+    renderer: 'solid'
+  },
   title: 'Solid/Counter',
   component: Counter,
   args: {},

--- a/src/stories/Svelte.stories.js
+++ b/src/stories/Svelte.stories.js
@@ -1,6 +1,9 @@
 import Counter from '../components/svelte/Counter.svelte';
 
 export default {
+  parameters: {
+    renderer: 'svelte'
+  },
   title: 'Svelte/Counter',
   component: Counter,
   args: {},

--- a/src/stories/Vue.stories.js
+++ b/src/stories/Vue.stories.js
@@ -1,6 +1,9 @@
 import Counter from '../components/vue/Counter.vue';
 
 export default {
+  parameters: {
+    renderer: 'vue'
+  },
   title: 'Vue/Counter',
   component: Counter,
   args: {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,6 +740,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/standalone@npm:^7.26.2":
+  version: 7.27.0
+  resolution: "@babel/standalone@npm:7.27.0"
+  checksum: 10c0/ce5883feb4f5e2eef316075f488278fa41a6b57f7ff20715d4fd9bbdcb1867776dbd8998416515282506e149a7c9d0212d0f56ad2093069b1fe52122cafb9265
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.0, @babel/template@npm:^7.26.8":
   version: 7.26.8
   resolution: "@babel/template@npm:7.26.8"
@@ -1303,6 +1310,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/eslintrc@npm:^1.0.5":
+  version: 1.4.1
+  resolution: "@eslint/eslintrc@npm:1.4.1"
+  dependencies:
+    ajv: "npm:^6.12.4"
+    debug: "npm:^4.3.2"
+    espree: "npm:^9.4.0"
+    globals: "npm:^13.19.0"
+    ignore: "npm:^5.2.0"
+    import-fresh: "npm:^3.2.1"
+    js-yaml: "npm:^4.1.0"
+    minimatch: "npm:^3.1.2"
+    strip-json-comments: "npm:^3.1.1"
+  checksum: 10c0/1030e1a4a355f8e4629e19d3d45448a05a8e65ecf49154bebc66599d038f155e830498437cbfc7246e8084adc1f814904f696c2461707cc8c73be961e2e8ae5a
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.3.1":
   version: 3.3.1
   resolution: "@eslint/eslintrc@npm:3.3.1"
@@ -1361,10 +1385,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.9.2":
+  version: 0.9.5
+  resolution: "@humanwhocodes/config-array@npm:0.9.5"
+  dependencies:
+    "@humanwhocodes/object-schema": "npm:^1.2.1"
+    debug: "npm:^4.1.1"
+    minimatch: "npm:^3.0.4"
+  checksum: 10c0/6a6be8bb71443615b98dcf2136e31d7261289b32ef474c2f76b084940922d82b349c70111799c389d4eb02040e8f686e5a635283f65774853556c219a8699cc4
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/module-importer@npm:^1.0.1":
   version: 1.0.1
   resolution: "@humanwhocodes/module-importer@npm:1.0.1"
   checksum: 10c0/909b69c3b86d482c26b3359db16e46a32e0fb30bd306a3c176b8313b9e7313dba0f37f519de6aa8b0a1921349e505f259d19475e123182416a506d7f87e7f529
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/object-schema@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@humanwhocodes/object-schema@npm:1.2.1"
+  checksum: 10c0/c3c35fdb70c04a569278351c75553e293ae339684ed75895edc79facc7276e351115786946658d78133130c0cca80e57e2203bc07f8fa7fe7980300e8deef7db
   languageName: node
   linkType: hard
 
@@ -2229,18 +2271,39 @@ __metadata:
   resolution: "@storybook/astro@workspace:packages/@storybook/astro"
   dependencies:
     "@storybook/astro-renderer": "workspace:*"
+    "@storybook/preact": "npm:^8.6.12"
+    "@storybook/react": "npm:^8.6.12"
+    "@storybook/svelte": "npm:^8.6.12"
+    "@storybook/vue3": "npm:^8.6.12"
+    "@sveltejs/vite-plugin-svelte": "npm:^5.0.3"
     "@types/node": "npm:^20.17.30"
+    "@vitejs/plugin-react": "npm:^4.3.4"
+    alpinejs: "npm:^3.14.9"
     astro: "npm:^5.6.1"
+    storybook-solidjs: "npm:^1.0.0-beta.7"
+    vite-plugin-solid: "npm:^2.11.6"
   peerDependencies:
-    "@astrojs/preact": "*"
-    "@astrojs/react": "*"
-    "@astrojs/solid-js": "*"
-    "@astrojs/svelte": "*"
-    "@astrojs/vue": "*"
+    "@astrojs/alpinejs": ^0.4.5
+    "@astrojs/preact": ^4.0.8
+    "@astrojs/react": ^4.2.3
+    "@astrojs/solid-js": ^5.0.7
+    "@astrojs/svelte": ^7.0.9
+    "@astrojs/vue": ^5.0.9
+    "@preact/preset-vite": ^2.10.1
+    "@storybook/preact": ^8.6.12
+    "@storybook/react": ^8.6.12
+    "@storybook/svelte": ^8.6.12
+    "@storybook/vue3": ^8.6.12
+    "@vitejs/plugin-react": ^4.3.4
+    "@vitejs/plugin-vue": ^5.2.3
+    "@vitejs/plugin-vue-jsx": ^4.1.2
     astro: ^4.14.6
-    storybook: "*"
-    vite: "*"
+    storybook: ^8.6.12
+    storybook-solidjs: ^1.0.0-beta.7
+    vite: ^6.2.5
   peerDependenciesMeta:
+    "@astrojs/alpinejs":
+      optional: true
     "@astrojs/preact":
       optional: true
     "@astrojs/react":
@@ -2250,6 +2313,22 @@ __metadata:
     "@astrojs/svelte":
       optional: true
     "@astrojs/vue":
+      optional: true
+    "@preact/preset-vite":
+      optional: true
+    "@storybook/preact":
+      optional: true
+    "@storybook/react":
+      optional: true
+    "@storybook/svelte":
+      optional: true
+    "@storybook/vue3":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    "@vitejs/plugin-vue-jsx":
+      optional: true
+    storybook-solidjs:
       optional: true
   languageName: unknown
   linkType: soft
@@ -2331,6 +2410,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/csf@npm:0.1.12":
+  version: 0.1.12
+  resolution: "@storybook/csf@npm:0.1.12"
+  dependencies:
+    type-fest: "npm:^2.19.0"
+  checksum: 10c0/3d96a976ada67eb683279338d1eb6aa730b228107d4c4f6616ea7b94061899c1fdc11957a756e7bc0708d18cb39af0010c865d124efd84559cd82dcb2d8bc959
+  languageName: node
+  linkType: hard
+
+"@storybook/docs-tools@npm:next":
+  version: 9.0.0-alpha.1
+  resolution: "@storybook/docs-tools@npm:9.0.0-alpha.1"
+  peerDependencies:
+    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0 || ^9.0.0-0
+  checksum: 10c0/f8dc70365fac2bfae010b6374cb63e6e095ac871979ba78bd7ea6a4be8822920f1e66f5995acfc7040e6769e948e84e2cd7a0a8fc15d7ba4bc9857701bf75c11
+  languageName: node
+  linkType: hard
+
 "@storybook/global@npm:^5.0.0":
   version: 5.0.0
   resolution: "@storybook/global@npm:5.0.0"
@@ -2369,12 +2466,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/preact@npm:^8.6.12":
+  version: 8.6.12
+  resolution: "@storybook/preact@npm:8.6.12"
+  dependencies:
+    "@storybook/components": "npm:8.6.12"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/manager-api": "npm:8.6.12"
+    "@storybook/preview-api": "npm:8.6.12"
+    "@storybook/theming": "npm:8.6.12"
+    ts-dedent: "npm:^2.0.0"
+  peerDependencies:
+    preact: ^8.0.0||^10.0.0
+    storybook: ^8.6.12
+  checksum: 10c0/bcf9a719b2c38d6d327464e074ff2c43b1f033cb7a5eabf8429803da3955df690d1a49cb4a2067fe44dc08e6768a67349bf78af6a9c2cd10e3149d0f6e4fafec
+  languageName: node
+  linkType: hard
+
 "@storybook/preview-api@npm:8.6.12":
   version: 8.6.12
   resolution: "@storybook/preview-api@npm:8.6.12"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
   checksum: 10c0/38044f40a0ac060ab33ed84eff62da1a99cdb5a2f73e6786b58da4cf5c4295d4ef060373f1fdaa1bfe6cccea8e123768d046555adf98a4acf1abda40fa3e9781
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-api@npm:next":
+  version: 9.0.0-alpha.1
+  resolution: "@storybook/preview-api@npm:9.0.0-alpha.1"
+  peerDependencies:
+    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0 || ^9.0.0-0
+  checksum: 10c0/d83777566098a62cc29e8ca96b123e3b377ce3c08de782e504d5478e8e9101f00e4a355f5ecfbec9435e88137bc8c324013f520d2608f1ddbe96f8e80c50be4f
   languageName: node
   linkType: hard
 
@@ -2440,6 +2563,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/svelte@npm:^8.6.12":
+  version: 8.6.12
+  resolution: "@storybook/svelte@npm:8.6.12"
+  dependencies:
+    "@storybook/components": "npm:8.6.12"
+    "@storybook/csf": "npm:0.1.12"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/manager-api": "npm:8.6.12"
+    "@storybook/preview-api": "npm:8.6.12"
+    "@storybook/theming": "npm:8.6.12"
+    sveltedoc-parser: "npm:^4.2.1"
+    ts-dedent: "npm:^2.0.0"
+    type-fest: "npm:~2.19"
+  peerDependencies:
+    storybook: ^8.6.12
+    svelte: ^4.0.0 || ^5.0.0
+  checksum: 10c0/607d716998821f32549d37885a3349f1363ccd2c1c7970e52c57b98a8931c28614d6cadef519a9ddb61da8cc67460c5d2ca97390033779b0f7dad547f254167d
+  languageName: node
+  linkType: hard
+
 "@storybook/test@npm:8.6.12, @storybook/test@npm:^8.6.12":
   version: 8.6.12
   resolution: "@storybook/test@npm:8.6.12"
@@ -2463,6 +2606,35 @@ __metadata:
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
   checksum: 10c0/cd7033dbc9415d765fd15a60c058ea039ce02a84c7cdbe6d7e597adb418694f28ac7cacf849cccef1e8b4374e7fa0df5010f801e6b55844c2fa391968eecba3c
+  languageName: node
+  linkType: hard
+
+"@storybook/types@npm:next":
+  version: 9.0.0-alpha.1
+  resolution: "@storybook/types@npm:9.0.0-alpha.1"
+  peerDependencies:
+    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0 || ^9.0.0-0
+  checksum: 10c0/795387ab41ba453357fbda1a64f49724ac40bf4c043785fb42de046ae96ec967fdc234f993618f7de54be0f78c16056b9b26e43e957d61b686a659f7e3f11790
+  languageName: node
+  linkType: hard
+
+"@storybook/vue3@npm:^8.6.12":
+  version: 8.6.12
+  resolution: "@storybook/vue3@npm:8.6.12"
+  dependencies:
+    "@storybook/components": "npm:8.6.12"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/manager-api": "npm:8.6.12"
+    "@storybook/preview-api": "npm:8.6.12"
+    "@storybook/theming": "npm:8.6.12"
+    "@vue/compiler-core": "npm:^3.0.0"
+    ts-dedent: "npm:^2.0.0"
+    type-fest: "npm:~2.19"
+    vue-component-type-helpers: "npm:latest"
+  peerDependencies:
+    storybook: ^8.6.12
+    vue: ^3.0.0
+  checksum: 10c0/8c1e4a7a6ac3123cc43e5084f3ae99d2a0fc14cef1fa7e1a99db3792181ba9d14b84818c156cef10067b24f1b4a2e89915a8dea01ec804d6b40930ba549c42c1
   languageName: node
   linkType: hard
 
@@ -2595,6 +2767,12 @@ __metadata:
   checksum: 10c0/f0ba105e7d2296bf367d6e055bb22996886c114261e2cb70bf9359556d0076c7a57239d019dee42bb063f565bade5ccb46009bce2044b2952d964bf9a454d6d2
   languageName: node
   linkType: hard
+
+"@types/babel__standalone@link:.yarn/cache/null::locator=storybook-solidjs%40npm%3A1.0.0-beta.7":
+  version: 0.0.0-use.local
+  resolution: "@types/babel__standalone@link:.yarn/cache/null::locator=storybook-solidjs%40npm%3A1.0.0-beta.7"
+  languageName: node
+  linkType: soft
 
 "@types/babel__template@npm:*":
   version: 7.4.4
@@ -3172,7 +3350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.5.13":
+"@vue/compiler-core@npm:3.5.13, @vue/compiler-core@npm:^3.0.0":
   version: 3.5.13
   resolution: "@vue/compiler-core@npm:3.5.13"
   dependencies:
@@ -3335,7 +3513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.2":
+"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -3344,7 +3522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.12.1, acorn@npm:^8.14.1":
+"acorn@npm:^8.12.1, acorn@npm:^8.14.1, acorn@npm:^8.6.0, acorn@npm:^8.9.0":
   version: 8.14.1
   resolution: "acorn@npm:8.14.1"
   bin:
@@ -3369,7 +3547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.12.4":
+"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -3396,6 +3574,13 @@ __metadata:
   dependencies:
     string-width: "npm:^4.1.0"
   checksum: 10c0/ad8b755a253a1bc8234eb341e0cec68a857ab18bf97ba2bda529e86f6e30460416523e0ec58c32e5c21f0ca470d779503244892873a5895dbd0c39c788e82467
+  languageName: node
+  linkType: hard
+
+"ansi-colors@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "ansi-colors@npm:4.1.3"
+  checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
   languageName: node
   linkType: hard
 
@@ -3591,6 +3776,15 @@ __metadata:
   peerDependencies:
     "@astrojs/compiler": ">=0.27.0"
   checksum: 10c0/bf2a81216fceac6cd53f367ac2df73902bc223f5a2223ffa1613678863a2b00759cd7cd57b1e2c8d1bf137e99c5e0624a2d667a36215b3ddc4aca61f83d7c107
+  languageName: node
+  linkType: hard
+
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/9096e6ad6b674c894d8ddd5aa4c512b09bb05931b8746ebd634952b05685608b2b0820ed5c406e6569919ff5fe237ab3c491e6f2887d6da6b6ba906db3ee9c32
   languageName: node
   linkType: hard
 
@@ -4089,7 +4283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -4152,7 +4346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -4333,6 +4527,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^1.0.1":
+  version: 1.4.1
+  resolution: "dom-serializer@npm:1.4.1"
+  dependencies:
+    domelementtype: "npm:^2.0.1"
+    domhandler: "npm:^4.2.0"
+    entities: "npm:^2.0.0"
+  checksum: 10c0/67d775fa1ea3de52035c98168ddcd59418356943b5eccb80e3c8b3da53adb8e37edb2cc2f885802b7b1765bf5022aec21dfc32910d7f9e6de4c3148f095ab5e0
+  languageName: node
+  linkType: hard
+
 "dom-serializer@npm:^2.0.0":
   version: 2.0.0
   resolution: "dom-serializer@npm:2.0.0"
@@ -4344,10 +4549,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domelementtype@npm:^2.3.0":
+"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0, domelementtype@npm:^2.3.0":
   version: 2.3.0
   resolution: "domelementtype@npm:2.3.0"
   checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^3.0.0":
+  version: 3.3.0
+  resolution: "domhandler@npm:3.3.0"
+  dependencies:
+    domelementtype: "npm:^2.0.1"
+  checksum: 10c0/376e6462a6144121f6ae50c9c1b8e0b22d2e0c68f9fb2ef6e57a5f4f9395854b1258cb638c58b171ee291359a5f41a4a57f403954db976484a59ffcee4c1e405
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^4.2.0":
+  version: 4.3.1
+  resolution: "domhandler@npm:4.3.1"
+  dependencies:
+    domelementtype: "npm:^2.2.0"
+  checksum: 10c0/5c199c7468cb052a8b5ab80b13528f0db3d794c64fc050ba793b574e158e67c93f8336e87fd81e9d5ee43b0e04aea4d8b93ed7be4899cb726a1601b3ba18538b
   languageName: node
   linkType: hard
 
@@ -4357,6 +4580,17 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^2.0.0":
+  version: 2.8.0
+  resolution: "domutils@npm:2.8.0"
+  dependencies:
+    dom-serializer: "npm:^1.0.1"
+    domelementtype: "npm:^2.2.0"
+    domhandler: "npm:^4.2.0"
+  checksum: 10c0/d58e2ae01922f0dd55894e61d18119924d88091837887bf1438f2327f32c65eb76426bd9384f81e7d6dcfb048e0f83c19b222ad7101176ad68cdc9c695b563db
   languageName: node
   linkType: hard
 
@@ -4447,6 +4681,23 @@ __metadata:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
   checksum: 10c0/4cffd9b125225184e2abed9fdf0ed3dbd2224c873b165d0838fd066cde32e0918626cba2f1f4bf6860762f13a7e2364fd89a82b99566be2873d813573ac71846
+  languageName: node
+  linkType: hard
+
+"enquirer@npm:^2.3.5":
+  version: 2.4.1
+  resolution: "enquirer@npm:2.4.1"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/43850479d7a51d36a9c924b518dcdc6373b5a8ae3401097d336b7b7e258324749d0ad37a1fcaa5706f04799baa05585cd7af19ebdf7667673e7694435fcea918
+  languageName: node
+  linkType: hard
+
+"entities@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 10c0/7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
   languageName: node
   linkType: hard
 
@@ -4899,6 +5150,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope@npm:^7.1.0":
+  version: 7.2.2
+  resolution: "eslint-scope@npm:7.2.2"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/613c267aea34b5a6d6c00514e8545ef1f1433108097e857225fed40d397dd6b1809dffd11c2fde23b37ca53d7bf935fe04d2a18e6fc932b31837b6ad67e1c116
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^8.0.1, eslint-scope@npm:^8.2.0, eslint-scope@npm:^8.3.0":
   version: 8.3.0
   resolution: "eslint-scope@npm:8.3.0"
@@ -4909,7 +5170,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.4.3":
+"eslint-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eslint-utils@npm:3.0.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^2.0.0"
+  peerDependencies:
+    eslint: ">=5"
+  checksum: 10c0/45aa2b63667a8d9b474c98c28af908d0a592bed1a4568f3145cd49fb5d9510f545327ec95561625290313fe126e6d7bdfe3fdbdb6f432689fab6b9497d3bfb52
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "eslint-visitor-keys@npm:2.1.0"
+  checksum: 10c0/9f0e3a2db751d84067d15977ac4b4472efd6b303e369e6ff241a99feac04da758f46d5add022c33d06b53596038dbae4b4aceb27c7e68b8dfc1055b35e495787
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^3.1.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
@@ -4920,6 +5199,54 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
+  languageName: node
+  linkType: hard
+
+"eslint@npm:8.4.1":
+  version: 8.4.1
+  resolution: "eslint@npm:8.4.1"
+  dependencies:
+    "@eslint/eslintrc": "npm:^1.0.5"
+    "@humanwhocodes/config-array": "npm:^0.9.2"
+    ajv: "npm:^6.10.0"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.2"
+    debug: "npm:^4.3.2"
+    doctrine: "npm:^3.0.0"
+    enquirer: "npm:^2.3.5"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^7.1.0"
+    eslint-utils: "npm:^3.0.0"
+    eslint-visitor-keys: "npm:^3.1.0"
+    espree: "npm:^9.2.0"
+    esquery: "npm:^1.4.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^6.0.1"
+    functional-red-black-tree: "npm:^1.0.1"
+    glob-parent: "npm:^6.0.1"
+    globals: "npm:^13.6.0"
+    ignore: "npm:^4.0.6"
+    import-fresh: "npm:^3.0.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    js-yaml: "npm:^4.1.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    levn: "npm:^0.4.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.0.4"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.1"
+    progress: "npm:^2.0.0"
+    regexpp: "npm:^3.2.0"
+    semver: "npm:^7.2.1"
+    strip-ansi: "npm:^6.0.1"
+    strip-json-comments: "npm:^3.1.0"
+    text-table: "npm:^0.2.0"
+    v8-compile-cache: "npm:^2.0.3"
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/964a3e10e20c77cc9aef11ef950cffe42ae6825c1106101ec867218b52d9ae1dbf455955799b5e68f6d98650a880646d1951bdbd923c99af8907e910458b648a
   languageName: node
   linkType: hard
 
@@ -4980,6 +5307,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"espree@npm:9.2.0":
+  version: 9.2.0
+  resolution: "espree@npm:9.2.0"
+  dependencies:
+    acorn: "npm:^8.6.0"
+    acorn-jsx: "npm:^5.3.1"
+    eslint-visitor-keys: "npm:^3.1.0"
+  checksum: 10c0/fa0acceb6bf151193b873379ba8ee3771c93ce3b656aeb9fe4a36adcf170e315925096e8addddd2d347ae6026ab18febc5892e314e6b109b61a9c3be75f88dc0
+  languageName: node
+  linkType: hard
+
 "espree@npm:^10.0.0, espree@npm:^10.0.1, espree@npm:^10.3.0":
   version: 10.3.0
   resolution: "espree@npm:10.3.0"
@@ -4988,6 +5326,17 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/272beeaca70d0a1a047d61baff64db04664a33d7cfb5d144f84bc8a5c6194c6c8ebe9cc594093ca53add88baa23e59b01e69e8a0160ab32eac570482e165c462
+  languageName: node
+  linkType: hard
+
+"espree@npm:^9.2.0, espree@npm:^9.4.0":
+  version: 9.6.1
+  resolution: "espree@npm:9.6.1"
+  dependencies:
+    acorn: "npm:^8.9.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: 10c0/1a2e9b4699b715347f62330bcc76aee224390c28bb02b31a3752e9d07549c473f5f986720483c6469cf3cfb3c9d05df612ffc69eb1ee94b54b739e67de9bb460
   languageName: node
   linkType: hard
 
@@ -5001,7 +5350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0, esquery@npm:^1.6.0":
+"esquery@npm:^1.4.0, esquery@npm:^1.5.0, esquery@npm:^1.6.0":
   version: 1.6.0
   resolution: "esquery@npm:1.6.0"
   dependencies:
@@ -5184,6 +5533,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "file-entry-cache@npm:6.0.1"
+  dependencies:
+    flat-cache: "npm:^3.0.4"
+  checksum: 10c0/58473e8a82794d01b38e5e435f6feaf648e3f36fdb3a56e98f417f4efae71ad1c0d4ebd8a9a7c50c3ad085820a93fc7494ad721e0e4ebc1da3573f4e1c3c7cdd
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -5227,6 +5585,17 @@ __metadata:
     pkg-types: "npm:^1.0.3"
     yaml: "npm:^2.3.4"
   checksum: 10c0/e28dd30a753d9cabc1c9e94746ef75be181ce6403d9987c9efac7379ab94c8f776f541acd342907f3077cf288b6464dc807b30b57b2ded96a3e1caca0da3b10a
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^3.0.4":
+  version: 3.2.0
+  resolution: "flat-cache@npm:3.2.0"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.3"
+    rimraf: "npm:^3.0.2"
+  checksum: 10c0/b76f611bd5f5d68f7ae632e3ae503e678d205cf97a17c6ab5b12f6ca61188b5f1f7464503efae6dc18683ed8f0b41460beb48ac4b9ac63fe6201296a91ba2f75
   languageName: node
   linkType: hard
 
@@ -5293,6 +5662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs.realpath@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs.realpath@npm:1.0.0"
+  checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
@@ -5316,6 +5692,13 @@ __metadata:
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
   checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
+"functional-red-black-tree@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "functional-red-black-tree@npm:1.0.1"
+  checksum: 10c0/5959eed0375803d9924f47688479bb017e0c6816a0e5ac151e22ba6bfe1d12c41de2f339188885e0aa8eeea2072dad509d8e4448467e816bde0a2ca86a0670d3
   languageName: node
   linkType: hard
 
@@ -5396,7 +5779,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^6.0.2":
+"glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
@@ -5421,10 +5804,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.1.3":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10c0/65676153e2b0c9095100fe7f25a778bf45608eeb32c6048cf307f579649bcc30353277b3b898a3792602c65764e5baa4f643714dfbdfd64ea271d210c7a425fe
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
   checksum: 10c0/758f9f258e7b19226bd8d4af5d3b0dcf7038780fb23d82e6f98932c44e239f884847f1766e8fa9cc5635ccb3204f7fa7314d4408dd4002a5e8ea827b4018f0a1
+  languageName: node
+  linkType: hard
+
+"globals@npm:^13.19.0, globals@npm:^13.6.0":
+  version: 13.24.0
+  resolution: "globals@npm:13.24.0"
+  dependencies:
+    type-fest: "npm:^0.20.2"
+  checksum: 10c0/d3c11aeea898eb83d5ec7a99508600fbe8f83d2cf00cbb77f873dbf2bcb39428eff1b538e4915c993d8a3b3473fa71eeebfe22c9bb3a3003d1e26b1f2c8a42cd
   languageName: node
   linkType: hard
 
@@ -5738,6 +6144,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"htmlparser2-svelte@npm:4.1.0":
+  version: 4.1.0
+  resolution: "htmlparser2-svelte@npm:4.1.0"
+  dependencies:
+    domelementtype: "npm:^2.0.1"
+    domhandler: "npm:^3.0.0"
+    domutils: "npm:^2.0.0"
+    entities: "npm:^2.0.0"
+  checksum: 10c0/f80d3de85034ffac90706591e97722465ec44a54f24fb9b19c9710eefa7e4bf9944159d6f292bc12431239d7369114d87cf44dff553519e22f1e9e17c9aad2fd
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -5790,6 +6208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "ignore@npm:4.0.6"
+  checksum: 10c0/836ee7dc7fd9436096e2dba429359dbb9fa0e33d309e2b2d81692f375f6ca82024fc00567f798613d50c6b989e9cd2ad2b065acf116325cde177f02c86b7d4e0
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0, ignore@npm:^5.3.1, ignore@npm:^5.3.2":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -5797,7 +6222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
   dependencies:
@@ -5828,7 +6253,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:^2.0.3":
+"inflight@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "inflight@npm:1.0.6"
+  dependencies:
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
+  checksum: 10c0/7faca22584600a9dc5b9fca2cd5feb7135ac8c935449837b315676b4c90aa4f391ec4f42240178244b5a34e8bede1948627fda392ca3191522fc46b34e985ab2
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2, inherits@npm:^2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -6143,7 +6578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.4":
+"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -6906,7 +7341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -7221,6 +7656,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"once@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "once@npm:1.4.0"
+  dependencies:
+    wrappy: "npm:1"
+  checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
 "oniguruma-parser@npm:^0.5.4":
   version: 0.5.4
   resolution: "oniguruma-parser@npm:0.5.4"
@@ -7263,7 +7707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optionator@npm:^0.9.3":
+"optionator@npm:^0.9.1, optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
   dependencies:
@@ -7395,6 +7839,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-is-absolute@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "path-is-absolute@npm:1.0.1"
+  checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
   languageName: node
   linkType: hard
 
@@ -7687,6 +8138,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"progress@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "progress@npm:2.0.3"
+  checksum: 10c0/1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -7913,6 +8371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexpp@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "regexpp@npm:3.2.0"
+  checksum: 10c0/d1da82385c8754a1681416b90b9cca0e21b4a2babef159099b88f640637d789c69011d0bc94705dacab85b81133e929d027d85210e8b8b03f8035164dbc14710
+  languageName: node
+  linkType: hard
+
 "rehype-parse@npm:^9.0.0":
   version: 9.0.1
   resolution: "rehype-parse@npm:9.0.1"
@@ -8123,6 +8588,17 @@ __metadata:
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "rimraf@npm:3.0.2"
+  dependencies:
+    glob: "npm:^7.1.3"
+  bin:
+    rimraf: bin.js
+  checksum: 10c0/9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
   languageName: node
   linkType: hard
 
@@ -8348,21 +8824,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.2.1, semver@npm:^7.3.8, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5, semver@npm:^7.6.2, semver@npm:^7.6.3":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
     semver: bin/semver.js
   checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.8, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.1":
-  version: 7.7.1
-  resolution: "semver@npm:7.7.1"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
   languageName: node
   linkType: hard
 
@@ -8689,6 +9165,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"storybook-solidjs@npm:^1.0.0-beta.7":
+  version: 1.0.0-beta.7
+  resolution: "storybook-solidjs@npm:1.0.0-beta.7"
+  dependencies:
+    "@babel/standalone": "npm:^7.26.2"
+    "@storybook/docs-tools": "npm:next"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/preview-api": "npm:next"
+    "@storybook/types": "npm:next"
+    "@types/babel__standalone": "link:.yarn/cache/null"
+    async-mutex: "npm:^0.5.0"
+  peerDependencies:
+    "@storybook/test": "*"
+    solid-js: ~1.9.0
+    storybook: "*"
+  peerDependenciesMeta:
+    "@storybook/test":
+      optional: true
+  checksum: 10c0/212334a1e20a5da263927ea54b69c2c0ddfc3689f15a983585d5a3813a59251d98398cda5164e65500e4b1456119355836a3740d4e931b396e5d1f9ac4984dda
+  languageName: node
+  linkType: hard
+
 "storybook@npm:^8.6.12":
   version: 8.6.12
   resolution: "storybook@npm:8.6.12"
@@ -8800,7 +9298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:^3.1.0, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
@@ -8895,6 +9393,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sveltedoc-parser@npm:^4.2.1":
+  version: 4.3.1
+  resolution: "sveltedoc-parser@npm:4.3.1"
+  dependencies:
+    eslint: "npm:8.4.1"
+    espree: "npm:9.2.0"
+    htmlparser2-svelte: "npm:4.1.0"
+  checksum: 10c0/38e0258956fcf1bbe2ecc61286b73e96eedbec62e236c6b3adfc7055a4b2b50034b99f887a9e5eaccac233a87ccbc9434abe156f6a3ef25a640dcb54a4b99f46
+  languageName: node
+  linkType: hard
+
 "svg-tags@npm:^1.0.0":
   version: 1.0.0
   resolution: "svg-tags@npm:1.0.0"
@@ -8940,6 +9449,13 @@ __metadata:
     mkdirp: "npm:^3.0.1"
     yallist: "npm:^5.0.0"
   checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
+  languageName: node
+  linkType: hard
+
+"text-table@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "text-table@npm:0.2.0"
+  checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
   languageName: node
   linkType: hard
 
@@ -9093,6 +9609,20 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.20.2":
+  version: 0.20.2
+  resolution: "type-fest@npm:0.20.2"
+  checksum: 10c0/dea9df45ea1f0aaa4e2d3bed3f9a0bfe9e5b2592bddb92eb1bf06e50bcf98dbb78189668cd8bc31a0511d3fc25539b4cd5c704497e53e93e2d40ca764b10bfc3
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^2.19.0, type-fest@npm:~2.19":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
   languageName: node
   linkType: hard
 
@@ -9440,6 +9970,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-compile-cache@npm:^2.0.3":
+  version: 2.4.0
+  resolution: "v8-compile-cache@npm:2.4.0"
+  checksum: 10c0/387851192545e7f4d691ba674de90890bba76c0f08ee4909ab862377f556221e75b3a361466490e201203401d64d7795f889882bdabc98b6f3c0bf1038a535be
+  languageName: node
+  linkType: hard
+
 "validate-html-nesting@npm:^1.2.1":
   version: 1.2.2
   resolution: "validate-html-nesting@npm:1.2.2"
@@ -9775,6 +10312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue-component-type-helpers@npm:latest":
+  version: 2.2.8
+  resolution: "vue-component-type-helpers@npm:2.2.8"
+  checksum: 10c0/c1dfd755ddee15d38057404f101ee607757f88de18e0dd03ad2677be7b0688d86e79e9dab54df9800347abe9826246fc4abbcb54e7827d9289808ba288347bfd
+  languageName: node
+  linkType: hard
+
 "vue-eslint-parser@npm:^10.1.3":
   version: 10.1.3
   resolution: "vue-eslint-parser@npm:10.1.3"
@@ -9939,6 +10483,13 @@ __metadata:
     string-width: "npm:^7.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/a139b818da9573677548dd463bd626a5a5286271211eb6e4e82f34a4f643191d74e6d4a9bb0a3c26ec90e6f904f679e0569674ac099ea12378a8b98e20706066
+  languageName: node
+  linkType: hard
+
+"wrappy@npm:1":
+  version: 1.0.2
+  resolution: "wrappy@npm:1.0.2"
+  checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Each UI framework now implements abstract `Integration` class. The class declares what should be used when rendering in Astro and Storybook.

Rest of the code is now almost entirely free of framework-specific code (except for one edge case for Solid).

This provides ground work for #4 (frameworks can declare their dependencies, we now have to loop through the array and try to resolve modules).

Closes #3 and #9